### PR TITLE
Add Database name as a dimension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # timescaledb-metrics
-Send [TimescaleDB](https://github.com/timescale/timescaledb) [policy stats](https://docs.timescale.com/latest/api#timescaledb_information-policy_stats) (and other things) as metrics. 
-
-# timescaledb-metrics
-Send metrics for policies and other things
+Send [TimescaleDB](https://github.com/timescale/timescaledb) [policy stats](https://docs.timescale.com/latest/api#timescaledb_information-policy_stats) (and other things) as metrics.
 
 # Usage
 

--- a/conn.go
+++ b/conn.go
@@ -1,6 +1,8 @@
 package main
 
-import "github.com/jackc/pgx"
+import (
+	"github.com/jackc/pgx"
+)
 
 func dbConn(dbURL string) (*pgx.Conn, error) {
 	var cfg pgx.ConnConfig

--- a/testdata/records.log
+++ b/testdata/records.log
@@ -1,9 +1,9 @@
-{"entity":"sli_300","job_type":"drop_chunks","last_start":1600244728,"last_success":1600244728,"total_fail":0}
-{"entity":"custom_sli_archive","job_type":"reorder","last_start":1600195293,"last_success":1600195293,"total_fail":0}
-{"entity":"custom_sli_archive","job_type":"compress_chunks","last_start":1600162096,"last_success":1600162096,"total_fail":0}
-{"entity":"custom_sli_archive","job_type":"drop_chunks","last_start":1600241297,"last_success":1600241297,"total_fail":0}
-{"entity":"sli_archive","job_type":"reorder","last_start":1600195323,"last_success":1600195323,"total_fail":0}
-{"entity":"sli_300","job_type":"continuous_aggregate","last_start":1600244763,"last_success":1600244763,"total_fail":0}
-{"entity":"sli_archive","job_type":"drop_chunks","last_start":1600241297,"last_success":1600241297,"total_fail":0}
-{"entity":"sli_archive","job_type":"compress_chunks","last_start":1600171382,"last_success":1600171382,"total_fail":0}
-{"entity":"sli_violations_archive","job_type":"drop_chunks","last_start":1600162101,"last_success":1600162101,"total_fail":0}
+{"database": "test", "entity":"sli_300","job_type":"drop_chunks","last_start":1600244728,"last_success":1600244728,"total_fail":0}
+{"database": "test", "entity":"custom_sli_archive","job_type":"reorder","last_start":1600195293,"last_success":1600195293,"total_fail":0}
+{"database": "test", "entity":"custom_sli_archive","job_type":"compress_chunks","last_start":1600162096,"last_success":1600162096,"total_fail":0}
+{"database": "test", "entity":"custom_sli_archive","job_type":"drop_chunks","last_start":1600241297,"last_success":1600241297,"total_fail":0}
+{"database": "test", "entity":"sli_archive","job_type":"reorder","last_start":1600195323,"last_success":1600195323,"total_fail":0}
+{"database": "test", "entity":"sli_300","job_type":"continuous_aggregate","last_start":1600244763,"last_success":1600244763,"total_fail":0}
+{"database": "test", "entity":"sli_archive","job_type":"drop_chunks","last_start":1600241297,"last_success":1600241297,"total_fail":0}
+{"database": "test", "entity":"sli_archive","job_type":"compress_chunks","last_start":1600171382,"last_success":1600171382,"total_fail":0}
+{"database": "test", "entity":"sli_violations_archive","job_type":"drop_chunks","last_start":1600162101,"last_success":1600162101,"total_fail":0}


### PR DESCRIPTION
The same database process may be hosting multiple databases.
Its important to separate them out, to avoid metric conflict.